### PR TITLE
Check revalidated response is storable in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ if (!oldPolicy.satisfiesWithoutRevalidation(newRequest)) {
     const response = modified ? newResponse : oldResponse;
 
     // Update the cache with the newer/fresher response
-    letsPretendThisIsSomeCache.set(newRequest.url, {policy, response}, policy.timeToLive());
+    if (policy.storable()) {
+      letsPretendThisIsSomeCache.set(newRequest.url, {policy, response}, policy.timeToLive());
+    }
 
     // And proceed returning cached response as usual
     response.headers = policy.responseHeaders();


### PR DESCRIPTION
It's possible that a revalidated response should not be stored. e.g has `Cache-Control: no-store` header. Therefore it should be explicitly checked to see if it's storable rather than assuming it still is.