### PR TITLE
Don't publish unnecessary files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "test": "npm run compile; mocha node4/test"
   },
   "files": [
-    "node4/index.js",
-    "index.js",
-    "test"
+    "node4/index.js"
   ],
   "author": "Kornel Lesiński <kornel@geekhood.net> (https://kornel.ski/)",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
`index.js` and `test/*.js` don't need to be published to npm and add a lot of bloat to the package size.

Not publishing them should result in a saving of 84K, bringing the package down from 132K to 48K.

```
$ du -hd 0 node_modules/http-cache-semantics
132K	node_modules/http-cache-semantics

$ rm -rf node_modules/http-cache-semantics/test node_modules/http-cache-semantics/index.js

$ du -hd 0 node_modules/http-cache-semantics
 48K	node_modules/http-cache-semantics
```